### PR TITLE
Tolerance: warn on zero-width interval, error on reversed bounds

### DIFF
--- a/sagepy/sagepy/core/mass.py
+++ b/sagepy/sagepy/core/mass.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List
 
 import sagepy_connector
@@ -60,15 +61,53 @@ class Tolerance:
         """Tolerance class
 
         Args:
-            da (float, optional): The tolerance in Da. Defaults to None.
-            ppm (float, optional): The tolerance in ppm. Defaults to None.
+            da (float, optional): Signed (low, high) tolerance in Da. The
+                conventional symmetric form is e.g. ``(-0.5, 0.5)``. Defaults
+                to None.
+            ppm (float, optional): Signed (low, high) tolerance in ppm. The
+                conventional symmetric form is e.g. ``(-10.0, 10.0)``. Note
+                that this is a SIGNED interval — passing ``(10.0, 10.0)``
+                yields a zero-width window that never matches anything.
+                Defaults to None.
+
+        Raises:
+            ValueError: if both / neither of da and ppm are provided, or if
+                low > high (reversed interval).
         """
         if da is not None and ppm is not None:
             raise ValueError("Only one of da or ppm can be set")
         elif da is None and ppm is None:
             raise ValueError("One of da or ppm must be set")
-        else:
-            self.__tolerance_ptr = psc.PyTolerance(da, ppm)
+
+        # Validate the (low, high) interval for whichever unit was supplied.
+        # A reversed interval is always a bug; a zero-width interval almost
+        # always is too — historically this footgun manifested as silent
+        # 0-PSM searches when callers wrote `Tolerance(ppm=(20, 20))` meaning
+        # "±20 ppm". Loud-warn on equal bounds, hard-error on swapped bounds.
+        bounds = ppm if ppm is not None else da
+        unit   = "ppm" if ppm is not None else "da"
+        try:
+            lo, hi = float(bounds[0]), float(bounds[1])
+        except (TypeError, IndexError, ValueError) as e:
+            raise ValueError(
+                f"{unit} must be a (low, high) tuple of two numbers"
+            ) from e
+        if lo > hi:
+            raise ValueError(
+                f"Tolerance({unit}=({lo}, {hi})): low > high — the interval "
+                f"is reversed; expected low <= high "
+                f"(e.g. {unit}=({-abs(hi)}, {abs(hi)}) for ±{abs(hi)})"
+            )
+        if lo == hi:
+            warnings.warn(
+                f"Tolerance({unit}=({lo}, {hi})): zero-width interval — "
+                f"this matches nothing. Did you mean "
+                f"{unit}=({-abs(hi)}, {abs(hi)})?",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        self.__tolerance_ptr = psc.PyTolerance(da, ppm)
 
     def get_py_ptr(self):
         return self.__tolerance_ptr

--- a/sagepy/tests/test_mass.py
+++ b/sagepy/tests/test_mass.py
@@ -1,4 +1,5 @@
 """Tests for sagepy.core.mass module."""
+import warnings
 import pytest
 from sagepy.core.mass import Tolerance, Composition, CONSTANTS, monoisotopic
 
@@ -27,6 +28,43 @@ class TestTolerance:
         """Test that providing neither da nor ppm raises an error."""
         with pytest.raises(ValueError):
             Tolerance()
+
+    def test_zero_width_ppm_warns(self):
+        """A zero-width ppm window is almost always a mistake (the user
+        meant the symmetric form). It should warn but still construct."""
+        with pytest.warns(UserWarning, match="zero-width"):
+            tol = Tolerance(ppm=(20.0, 20.0))
+        assert tol.ppm == (20.0, 20.0)
+
+    def test_zero_width_da_warns(self):
+        """Same check for the Da branch."""
+        with pytest.warns(UserWarning, match="zero-width"):
+            tol = Tolerance(da=(0.5, 0.5))
+        assert tol.da == (0.5, 0.5)
+
+    def test_reversed_ppm_raises(self):
+        """A reversed (low > high) interval is always a bug."""
+        with pytest.raises(ValueError, match="reversed"):
+            Tolerance(ppm=(10.0, -10.0))
+
+    def test_reversed_da_raises(self):
+        """A reversed Da interval is always a bug."""
+        with pytest.raises(ValueError, match="reversed"):
+            Tolerance(da=(0.5, -0.5))
+
+    def test_symmetric_no_warning(self):
+        """The conventional symmetric usage must NOT warn."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes an exception
+            Tolerance(ppm=(-10.0, 10.0))
+            Tolerance(da=(-0.5, 0.5))
+
+    def test_asymmetric_no_warning(self):
+        """Legitimately asymmetric tolerances (e.g. systematic offset) must
+        not warn — only equal/reversed bounds are flagged."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Tolerance(ppm=(-5.0, 15.0))
 
     def test_ppm_bounds(self):
         """Test PPM tolerance bounds calculation.


### PR DESCRIPTION
## Summary

`Tolerance(ppm=(low, high))` is a SIGNED interval, but the most common
mistake at the call site is to pass `(ppm, ppm)` — meaning to express
±ppm — which produces a zero-width window that silently matches
nothing. This has shown up in user code (and in upstream tools that
embed sagepy) as searches that return 0 PSMs without any error or
diagnostic.

This PR makes the misuse loud:

- **Warn** (`UserWarning`) on `low == high` with a message that suggests
  the symmetric form, so the mistake surfaces immediately rather than
  being chased through the search pipeline.
- **Raise** `ValueError` on `low > high` — a reversed interval is
  unambiguously a bug that the underlying `PyTolerance` would happily
  accept.
- Update the docstring to call out the symmetric convention explicitly
  (so e.g. `ppm=(-10.0, 10.0)`, not `ppm=(10.0, 10.0)`).
- Add unit tests for zero-width, reversed, symmetric, and asymmetric
  cases. Genuinely asymmetric tolerances (offset systematic mass error)
  remain perfectly legal — no warning.

## Test plan

- [x] Existing tests in `tests/test_mass.py` still pass
- [x] New tests cover `(low == high)` warning, `(low > high)` error,
      symmetric / asymmetric no-warning paths
- [x] Smoke check with the installed `sagepy.core.Tolerance` confirms
      the warning fires on `(20, 20)` and the error fires on `(10, -10)`