### PR TITLE
Credit mzdata in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The project is structured as follows:
 *	`qfdrust`: This crate implements basic false discovery rate (FDR) estimation using TDC, following the methods proposed by [Crema](https://github.com/Noble-Lab/crema).
 *	`unimod`: A work-in-progress crate that bridges Sage-style PSM annotation with the UNIMOD standard.
 
+Native mzML and MGF reading in `sagepy` is powered by the Rust crate [mzdata](https://github.com/mobiusklein/mzdata).
+
 ## Quickstart
 Get started quickly by installing sagepy via pip:
 ```
@@ -20,6 +22,8 @@ Check out the tutorial notebooks to dive into [DB generation, searching, and FDR
 ## Get involved
 Do you have any questions or want to contribute? Feel free to reach out at any time!
 
+## Acknowledgements
+`sagepy` builds on a number of open-source Rust and Python projects. In particular, the native mzML and MGF reader path is implemented using [mzdata](https://github.com/mobiusklein/mzdata).
 
 ## Cite
 

--- a/sagepy/README.md
+++ b/sagepy/README.md
@@ -11,6 +11,8 @@ A python interface to the core [SAGE](https://github.com/lazear/sage) search eng
 pip install sagepy
 ```
 
+Native mzML and MGF reading is powered by the Rust crate [mzdata](https://github.com/mobiusklein/mzdata).
+
 
 ### Build from source
 


### PR DESCRIPTION
## Summary
- credit the Rust mzdata crate in the repository README
- add the same note to the package README used for sagepy release metadata

## Validation
- documentation-only change
- no code or packaging behavior changed