### PR TITLE
Track optimized sage-core (fork master): sparse Mods + slim Peptide compat

### DIFF
--- a/qfdrust/Cargo.toml
+++ b/qfdrust/Cargo.toml
@@ -10,7 +10,7 @@ rand = "0.9.0-beta.0"
 rustms = { git = "https://github.com/theGreatHerrLebert/rustims.git" }
 # rustms = { path = "../../rustims/rustms" }
 # sage-core = {path = "../../sage/crates/sage" }
-sage-core = { git = "https://github.com/theGreatHerrLebert/sage.git" }
+sage-core = { git = "https://github.com/theGreatHerrLebert/sage.git", branch = "master" }
 itertools = "0.13.0"
 serde = { version = "1.0.217", features = ["derive"] }
 ndarray = "0.16.1"

--- a/sagepy-connector/Cargo.toml
+++ b/sagepy-connector/Cargo.toml
@@ -8,7 +8,7 @@ name = "sagepy_connector"
 crate-type = ["cdylib"]
 
 [dependencies]
-sage-core = { git = "https://github.com/theGreatHerrLebert/sage.git" }
+sage-core = { git = "https://github.com/theGreatHerrLebert/sage.git", branch = "master" }
 qfdrust = { path  = "../qfdrust" }
 unimod = { path = "../unimod" }
 mzdata = { version = "0.63.4", default-features = false, features = ["mzml", "mgf", "zlib-ng-compat"] }

--- a/sagepy-connector/src/py_database.rs
+++ b/sagepy-connector/src/py_database.rs
@@ -177,8 +177,8 @@ impl PyIndexedDatabase {
 
         for (i, p) in self.inner.peptides.iter().enumerate() {
             // only add if there are modifications based on non-zero entries in the modifications vector
-            if p.modifications.iter().any(|m| *m != 0.0) {
-                mods.push((i, p.modifications.clone()));
+            if !p.modifications.is_empty() {
+                mods.push((i, p.modifications.to_dense(p.sequence.len())));
             }
         }
         mods

--- a/sagepy-connector/src/py_ion_series.rs
+++ b/sagepy-connector/src/py_ion_series.rs
@@ -121,7 +121,7 @@ impl PyIonSeries {
 
         for idx in 0..seq_len.saturating_sub(1) {
             let r = self.peptide.inner.sequence[idx];
-            let m = self.peptide.inner.modifications.get(idx).unwrap_or(&0.0);
+            let m = self.peptide.inner.modifications.mass_at(idx);
 
             cm += match self.kind.inner {
                 Kind::A | Kind::B | Kind::C => monoisotopic(r) + m,

--- a/sagepy-connector/src/py_peptide.rs
+++ b/sagepy-connector/src/py_peptide.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use std::sync::Arc;
 
 use crate::py_enzyme::{PyDigest, PyPosition};
-use sage_core::peptide::Peptide;
+use sage_core::peptide::{Mods, Peptide};
 
 #[pyclass]
 #[derive(Clone)]
@@ -38,7 +38,7 @@ impl PyPeptide {
             inner: Peptide {
                 decoy,
                 sequence: arc_sequence,
-                modifications: modifications,
+                modifications: Mods::from_dense(&modifications),
                 nterm: n_term,
                 cterm: c_term,
                 monoisotopic: mono_isotopic,
@@ -69,7 +69,7 @@ impl PyPeptide {
 
     #[getter]
     pub fn modifications(&self) -> Vec<f32> {
-        self.inner.modifications.clone()
+        self.inner.modifications.to_dense(self.inner.sequence.len())
     }
 
     #[getter]

--- a/sagepy-connector/src/py_scoring.rs
+++ b/sagepy-connector/src/py_scoring.rs
@@ -991,9 +991,11 @@ impl PyScorer {
                             .collect();
 
                         let sequence = std::str::from_utf8(&peptide.sequence).unwrap().to_string();
+                        let peptide_mods_dense =
+                            peptide.modifications.to_dense(peptide.sequence.len());
                         let sequence_with_mods = sage_sequence_to_unimod_sequence(
                             sequence.clone(),
-                            &peptide.modifications,
+                            &peptide_mods_dense,
                             &self.expected_mods,
                         );
 
@@ -1001,9 +1003,12 @@ impl PyScorer {
                         let sequence_decoy = std::str::from_utf8(&peptide_reversed.sequence)
                             .unwrap()
                             .to_string();
+                        let peptide_reversed_mods_dense = peptide_reversed
+                            .modifications
+                            .to_dense(peptide_reversed.sequence.len());
                         let sequence_decoy_with_mods = sage_sequence_to_unimod_sequence(
                             sequence_decoy.clone(),
-                            &peptide_reversed.modifications,
+                            &peptide_reversed_mods_dense,
                             &self.expected_mods,
                         );
 


### PR DESCRIPTION
## Summary
- Adapts the connector to the sage-core build-memory optimization (sparse `Mods` with `to_dense`/`from_dense`; slimmed `Peptide` with `Box<[..]>` mods/proteins) — `py_peptide`, `py_ion_series`, `py_database`, `py_scoring`.
- Repoints the `sage-core` git dependency (connector + qfdrust) to the fork's **master**, where that optimization landed (`872b533`: sparse mods + struct-slim + chunked materialisation + a Bruker `.d` file://→local-path reader fix). Was pinned to the now-merged `perf/lazy-peptide-modifications` branch.

The old lock was stale at the A+D commit (`2d1ab6a`); this brings the connector current with the full landed work.

## Test plan
- [x] `cargo check` — qfdrust + connector compile against sage-core master
- [x] `maturin develop` builds the connector against sage-core master `872b5339`
- [x] `pytest sagepy/tests` — **103 passed** (incl. `test_peptide`, `test_ion_series`, `test_sage_compat`, `test_enzyme`, `test_fdr`)